### PR TITLE
Remove shortest and fix audio cutting bug

### DIFF
--- a/seewav.py
+++ b/seewav.py
@@ -247,7 +247,7 @@ def visualize(audio,
         "ffmpeg", "-y", "-loglevel", "panic", "-r",
         str(rate), "-f", "image2", "-s", f"{size[0]}x{size[1]}", "-i", "%06d.png"
     ] + audio_cmd + [
-        "-c:a", "aac", "-vcodec", "libx264", "-crf", "10", "-pix_fmt", "yuv420p", "-shortest",
+        "-c:a", "aac", "-vcodec", "libx264", "-crf", "10", "-pix_fmt", "yuv420p",
         out.resolve()
     ],
            check=True,


### PR DESCRIPTION
Relates to issue #8 

Context:

The -shortest flag in FFmpeg is used to specify that only the shortest input file should be used when concatenating multiple input files. This is useful when you want to combine multiple audio or video clips into a single file, but you don't want to include any clips that are longer than the others.

In this particular case we are creating the video from the audio so using`-shortest` doesn't make sense as they are both the exact same length.

There are two ways that I am aware of this bug manifests itself. One is as described in #8 where the audio cuts out towards the end of the clip. The other way is when you specify a short duration (1-3 seconds) that will lead to no audio at all from my testing.
